### PR TITLE
Fix HTTParty exception when using both search and query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,4 @@
 
 ## 1.0.0
 * **Breaking change**: Everytime you make a request `limit`, `page` and `search` no longer should be wrapped inside a `query` key.
-* Since making requests to `www.easybroker.com/api/v1` always redirects to the api subdomain, we updated the root URLs to avoid these redirections.Up
+* Updated endpoints to use the `api` subdomain; `api.easybroker.com/v1` instead of `www.easybroker.com/api/v1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@
 
 ## 0.1.4
 * Added support for the listing_statuses endpoint.
+
+## 1.0.0
+* **Breaking change**: Everytime you make a request `limit`, `page` and `search` no longer should be wrapped inside a `query` key.
+* Since making requests to `www.easybroker.com/api/v1` always redirects to the api subdomain, we updated the root URLs to avoid these redirections.Up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,5 @@
 * Added support for the listing_statuses endpoint for integration partners.
 
 ## 1.0.0
-* **Breaking change**: Everytime you make a request `limit`, `page` and `search` no longer should be wrapped inside a `query` key.
+* **Breaking change**: `limit`, `page`, and `search` params should be at the root level requests instead of in the `query` hash.
 * Updated endpoints to use the `api` subdomain; `api.easybroker.com/v1` instead of `www.easybroker.com/api/v1`.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ results.next_page
 
 
 # Search for only published properties
-client.properties.search(search: { statuses: [:published] } )
+client.properties.search(search: { statuses: [:published] }, limit: 1, page: 1)
 ```
 
 You can also pass a logger to log any methods that make remote calls. The logger class must implement a `log` method which will be called with the [HTTParty response](https://www.rubydoc.info/github/jnunemaker/httparty/HTTParty/Response) for every remote request sent.

--- a/lib/easy_broker/api_client.rb
+++ b/lib/easy_broker/api_client.rb
@@ -34,9 +34,7 @@ class EasyBroker::ApiClient
   private
 
   def send_request(verb, path = '', params = {})
-    query = params[:query] || params['query'] || {}
-
-    self.class.send(verb, path, params.merge(query)).tap do |response|
+    self.class.send(verb, path, params).tap do |response|
       check_errors(response)
       logger&.log response
     end

--- a/lib/easy_broker/constants.rb
+++ b/lib/easy_broker/constants.rb
@@ -5,7 +5,7 @@ module EasyBroker
     'Accept' => 'application/json',
     'User-Agent' => USER_AGENT
   }
-  DEFAULT_API_ROOT_URL = 'https://www.easybroker.com/api/v1'
-  STAGING_API_ROOT_URL = 'https://www.stagingeb.com/api/v1'
+  DEFAULT_API_ROOT_URL = 'https://api.easybroker.com/v1'
+  STAGING_API_ROOT_URL = 'https://api.stagingeb.com/v1'
   AUTHORIZATION_HEADER = 'X-Authorization'
 end

--- a/lib/easy_broker/query.rb
+++ b/lib/easy_broker/query.rb
@@ -2,6 +2,7 @@
 
 class EasyBroker::Query
   attr_reader :api_client, :endpoint, :query_params
+  DEFAULT_PAGE = 1
 
   def initialize(api_client, endpoint, query_params)
     @api_client = api_client
@@ -9,9 +10,15 @@ class EasyBroker::Query
     @query_params = query_params
   end
 
-  def get(page = 1)
-    query_params[:page] = page
+  def get(page = nil)
+    query_params[:page] = page_param(page)
     response = api_client.get(endpoint, query: query_params)
     JSON.parse(response.body, object_class: OpenStruct)
+  end
+
+  private
+
+  def page_param(page)
+    page || query_params[:page] || DEFAULT_PAGE
   end
 end

--- a/lib/easy_broker/query.rb
+++ b/lib/easy_broker/query.rb
@@ -11,14 +11,8 @@ class EasyBroker::Query
   end
 
   def get(page = nil)
-    query_params[:page] = page_param(page)
+    query_params[:page] = page if page
     response = api_client.get(endpoint, query: query_params)
     JSON.parse(response.body, object_class: OpenStruct)
-  end
-
-  private
-
-  def page_param(page)
-    page || query_params[:page] || DEFAULT_PAGE
   end
 end

--- a/lib/easy_broker/query.rb
+++ b/lib/easy_broker/query.rb
@@ -2,7 +2,6 @@
 
 class EasyBroker::Query
   attr_reader :api_client, :endpoint, :query_params
-  DEFAULT_PAGE = 1
 
   def initialize(api_client, endpoint, query_params)
     @api_client = api_client

--- a/lib/easy_broker/version.rb
+++ b/lib/easy_broker/version.rb
@@ -1,3 +1,3 @@
 module EasyBroker
-  VERSION = "2.0.0"
+  VERSION = "1.0.0"
 end

--- a/lib/easy_broker/version.rb
+++ b/lib/easy_broker/version.rb
@@ -1,3 +1,3 @@
 module EasyBroker
-  VERSION = "0.1.4"
+  VERSION = "2.0.0"
 end

--- a/test/contact_requests_test.rb
+++ b/test/contact_requests_test.rb
@@ -8,7 +8,7 @@ class ContactRequestsTest < EasyBrokerTestBase
   end
 
   def test_search
-    stub_verb_request(:get, '/contact_requests', query: { page: 1 }).
+    stub_verb_request(:get, '/contact_requests').
       to_return(body: mock_search_body.to_json)
     results = contact_requests.search
     assert_equal 1, results.first

--- a/test/integration_partners/listing_statuses_test.rb
+++ b/test/integration_partners/listing_statuses_test.rb
@@ -9,7 +9,7 @@ module IntegrationPartners
     end
 
     def test_search
-      stub_verb_request(:get, '/integration_partners/listing_statuses', query: { page: 1 }).
+      stub_verb_request(:get, '/integration_partners/listing_statuses').
         to_return(body: mock_search_body.to_json)
       results = statuses.search
       assert_equal 1, results.first

--- a/test/listing_statuses_test.rb
+++ b/test/listing_statuses_test.rb
@@ -8,7 +8,7 @@ class ListingStatusesTest < EasyBrokerTestBase
   end
 
   def test_search
-    stub_verb_request(:get, '/listing_statuses', query: { page: 1 }).
+    stub_verb_request(:get, '/listing_statuses').
       to_return(body: mock_search_body.to_json)
     results = statuses.search
     assert_equal 1, results.first

--- a/test/locations_test.rb
+++ b/test/locations_test.rb
@@ -8,7 +8,7 @@ class LocationsTest < EasyBrokerTestBase
   end
 
   def test_search
-    stub_verb_request(:get, '/locations', query: { page: 1 }).
+    stub_verb_request(:get, '/locations').
       to_return(body: mock_search_body.to_json)
     results = properties.search
     assert_equal 1, results.first

--- a/test/mls_properties_test.rb
+++ b/test/mls_properties_test.rb
@@ -15,7 +15,7 @@ class MlsPropertiesTest < EasyBrokerTestBase
   end
 
   def test_search
-    stub_verb_request(:get, '/mls_properties', query: { page: 1 }).
+    stub_verb_request(:get, '/mls_properties').
       to_return(body: mock_search_body.to_json)
     results = properties.search
     assert_equal 1, results.first

--- a/test/properties_test.rb
+++ b/test/properties_test.rb
@@ -15,7 +15,7 @@ class PropertiesTest < EasyBrokerTestBase
   end
 
   def test_search
-    stub_verb_request(:get, '/properties', query: { page: 1 }).
+    stub_verb_request(:get, '/properties').
       to_return(body: mock_search_body.to_json)
     results = properties.search
     assert_equal 1, results.first

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -3,15 +3,30 @@ require "test_helper"
 class QueryTest < Minitest::Test
   def test_get
     client = mock
-    client.expects(:get).with('test', query: { a: 2, page: 1 }).returns(mock_response)
+    client.expects(:get).with('test', query: { a: 2, page: EasyBroker::Query::DEFAULT_PAGE }).returns(mock_response)
 
     query = EasyBroker::Query.new(client, 'test', { a: 2 })
     results = query.get
     assert_equal results.a, 1
     assert_equal results.b, 2
+  end
 
+  def test_get_with_page_param
+    client = mock
     client.expects(:get).with('test', query: { a: 2, page: 2 }).returns(mock_response)
-    query.get(2)
+    query = EasyBroker::Query.new(client, 'test', { a: 2 })
+    results = query.get(2)
+    assert_equal results.a, 1
+    assert_equal results.b, 2
+  end
+
+  def test_get_with_initial_query_params
+    client = mock
+    client.expects(:get).with('test', query: { a: 2, page: 3 }).returns(mock_response)
+    query = EasyBroker::Query.new(client, 'test', { a: 2, page: 3 })
+    results = query.get
+    assert_equal results.a, 1
+    assert_equal results.b, 2
   end
 
   def mock_response

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -3,9 +3,8 @@ require "test_helper"
 class QueryTest < Minitest::Test
   def test_get
     client = mock
-    client.expects(:get).with('test', query: { a: 2, page: EasyBroker::Query::DEFAULT_PAGE }).returns(mock_response)
-
-    query = EasyBroker::Query.new(client, 'test', { a: 2 })
+    client.expects(:get).with('test', query: { a: 2, page: 3 }).returns(mock_response)
+    query = EasyBroker::Query.new(client, 'test', { a: 2, page: 3 })
     results = query.get
     assert_equal results.a, 1
     assert_equal results.b, 2
@@ -16,15 +15,6 @@ class QueryTest < Minitest::Test
     client.expects(:get).with('test', query: { a: 2, page: 2 }).returns(mock_response)
     query = EasyBroker::Query.new(client, 'test', { a: 2 })
     results = query.get(2)
-    assert_equal results.a, 1
-    assert_equal results.b, 2
-  end
-
-  def test_get_with_initial_query_params
-    client = mock
-    client.expects(:get).with('test', query: { a: 2, page: 3 }).returns(mock_response)
-    query = EasyBroker::Query.new(client, 'test', { a: 2, page: 3 })
-    results = query.get
     assert_equal results.a, 1
     assert_equal results.b, 2
   end


### PR DESCRIPTION
Currently when trying to use this gem and passing `search` and `query`
params to the `search` method, given the actual params handling,
the request only takes into account the `query` options, ignoring
all others.
Also, if you try to use `search(search: {...} page: 1, limit: 1)`
an exception is thrown by HTTParty. You have to do something
like `search(query: { search: { status: [:published] }, limit: 1, page: 1})`
to combine search and pagination params, which is not ideal.
This change attempts to fix the described behavior to allow using
`search(search: {...} page: 1, limit: 1)`, and also updates the
root url for staging and production.