### PR TITLE
Update httparty from 0.18 to 0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,11 @@
 * **Breaking change**: `limit`, `page`, and `search` params should be at the root level requests instead of in the `query` hash.
 * Updated endpoints to use the `api` subdomain; `api.easybroker.com/v1` instead of `www.easybroker.com/api/v1`.
 
-# 1.0.1
+## 1.0.1
 * Added support for agencies, agents, properties and property_integrations endpoints for integration partners.
 
-# 1.0.2
+## 1.0.2
 * Added support to configure the country code header for integration partners endpoints.
+
+## 1.0.3
+* Update httparty dependency from 0.18 to 0.21

--- a/easy_broker.gemspec
+++ b/easy_broker.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "httparty", "~> 0.18"
+  spec.add_dependency "httparty", "~> 0.21"
 
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/easy_broker/version.rb
+++ b/lib/easy_broker/version.rb
@@ -1,3 +1,3 @@
 module EasyBroker
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
This is a low priority update for [security reasons](https://github.com/easybroker/easybroker_gem/security/dependabot/4). Only httparty gem and [dependencies](https://rubygems.org/gems/httparty/versions/0.21.0/dependencies) will be updated.