### PR TITLE
Include configuration for Use Partner Code header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,6 @@
 
 ## 1.0.3
 * Update httparty dependency from 0.18 to 0.21
+
+## 1.0.4
+* Added support to configure the use partner code header for integration partners endpoints.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ EasyBroker.configure do |config|
 
   # As an integration partner you must configure the country code
   # config.country_code = 'MX'
+
+  # Get the information from the organizations connected to your site using a partner code
+  # config.use_partner_code = true
 end
 ```
 

--- a/lib/easy_broker/api_client.rb
+++ b/lib/easy_broker/api_client.rb
@@ -11,7 +11,8 @@ class EasyBroker::ApiClient
     self.class.base_uri EasyBroker.configuration.api_root_url
     self.class.headers EasyBroker::DEFAULT_HEADERS.merge(
       EasyBroker::AUTHORIZATION_HEADER => EasyBroker.configuration.api_key,
-      EasyBroker::COUNTRY_CODE_HEADER => EasyBroker.configuration.country_code
+      EasyBroker::COUNTRY_CODE_HEADER => EasyBroker.configuration.country_code,
+      EasyBroker::USE_PARTNER_CODE_HEADER => EasyBroker.configuration.use_partner_code&.to_s
     ).compact
     @logger = logger
   end

--- a/lib/easy_broker/configuration.rb
+++ b/lib/easy_broker/configuration.rb
@@ -1,9 +1,10 @@
 class EasyBroker::Configuration
-  attr_accessor :api_key, :api_root_url, :country_code
+  attr_accessor :api_key, :api_root_url, :country_code, :use_partner_code
 
   def initialize
     @api_key = nil
     @country_code = nil
+    @use_partner_code = nil
     @api_root_url = EasyBroker::DEFAULT_API_ROOT_URL
   end
 end

--- a/lib/easy_broker/constants.rb
+++ b/lib/easy_broker/constants.rb
@@ -9,4 +9,5 @@ module EasyBroker
   STAGING_API_ROOT_URL = 'https://api.stagingeb.com/v1'
   AUTHORIZATION_HEADER = 'X-Authorization'
   COUNTRY_CODE_HEADER  = 'Country-Code'
+  USE_PARTNER_CODE_HEADER  = 'Use-Partner-Code'
 end

--- a/lib/easy_broker/version.rb
+++ b/lib/easy_broker/version.rb
@@ -1,3 +1,3 @@
 module EasyBroker
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end

--- a/test/api_client_test.rb
+++ b/test/api_client_test.rb
@@ -12,6 +12,13 @@ class ApiClientTest < EasyBrokerTestBase
     client.get('test', query: { param1: 1, param2: 2 })
   end
 
+  def test_use_partner_code_header
+    stub_verb_request(:get, 'test').
+      with(headers: { 'Use-Partner-Code' => 'true' })
+    @client = EasyBroker::ApiClient.new
+    client.get('test')
+  end
+
   def test_country_code_header
     # The config for MX country is set in test_helper
     stub_verb_request(:get, 'test').

--- a/test/easy_broker_test.rb
+++ b/test/easy_broker_test.rb
@@ -7,6 +7,7 @@ class EasyBrokerTest < Minitest::Test
 
   def test_config
     # The config is set in test_helper
+    assert EasyBroker.configuration.use_partner_code
     assert_equal 'test_app_key', EasyBroker.configuration.api_key
     assert_equal 'MX', EasyBroker.configuration.country_code
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,4 +10,5 @@ require 'easy_broker_test_base'
 EasyBroker.configure do |config|
   config.api_key = 'test_app_key'
   config.country_code = 'MX'
+  config.use_partner_code = true
 end


### PR DESCRIPTION
This change includes an option to configure the use partner code header so the gem can work with the new integration partner endpoints changes.