### PR TITLE
Make the gem usable in stand-alone scripts

### DIFF
--- a/lib/easy_broker.rb
+++ b/lib/easy_broker.rb
@@ -1,4 +1,5 @@
 require 'httparty'
+require 'json'
 
 require 'easy_broker/version'
 require 'easy_broker/constants'


### PR DESCRIPTION
Why?
----

When trying to use the gem from within a Ruby script we get an
error indicating that the constant `JSON` is not initialized.

**Note**: This error doesn't happen if the gem is used within a
Rails app because of Rails' auto-loading feature that already
load `json` into memory.

What?
-----

Add the missing `require` statement.

How?
----

Add a `require` statement for `'json'` to
`easy_broker.rb`.

Fixes #9 