### PR TITLE
Change `EasyBroker::Locations#search` to `EasyBroker::Locations#find`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,6 @@
 
 ## 1.0.4
 * Added support to configure the use partner code header for integration partners endpoints.
+
+## 1.1.0
+* **Breaking change**: Changes `EasyBroker::Locations#search` to `EasyBroker::Locations#find`.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ EasyBroker.client(logger: my_logger)
 
 
 ```ruby
-client.locations # List and search geographic locations
+client.locations # Find geographic locations
 client.contact_requests # List and search contact requests in your account - TDB create via post
 client.properties # List, search and find properties in your account
 client.mls_properties # List, search and find properties in the MLS - requires MLS API Plan

--- a/lib/easy_broker/locations.rb
+++ b/lib/easy_broker/locations.rb
@@ -9,8 +9,9 @@ class EasyBroker::Locations
     @api_client = api_client
   end
 
-  def search(query = {})
-    stored_query = EasyBroker::Query.new(api_client, ENDPOINT, query)
-    EasyBroker::PaginatedResponse.new(stored_query)
+  def find(name = nil)
+    query = name ? { query: name } : {}
+    response = api_client.get(ENDPOINT, query: query)
+    JSON.parse(response.body, object_class: OpenStruct)
   end
 end

--- a/lib/easy_broker/locations.rb
+++ b/lib/easy_broker/locations.rb
@@ -10,7 +10,7 @@ class EasyBroker::Locations
   end
 
   def find(name = nil)
-    query = name ? { query: name } : {}
+    query = { query: name }.compact
     response = api_client.get(ENDPOINT, query: query)
     JSON.parse(response.body, object_class: OpenStruct)
   end

--- a/lib/easy_broker/version.rb
+++ b/lib/easy_broker/version.rb
@@ -1,3 +1,3 @@
 module EasyBroker
-  VERSION = "1.0.4"
+  VERSION = "1.1.0"
 end

--- a/test/locations_test.rb
+++ b/test/locations_test.rb
@@ -1,29 +1,16 @@
 require "test_helper"
 
 class LocationsTest < EasyBrokerTestBase
-  attr_reader :properties
+  attr_reader :locations
 
   def setup
-    @properties = EasyBroker::Locations.new(EasyBroker::ApiClient.new)
+    @locations = EasyBroker::Locations.new(EasyBroker::ApiClient.new)
   end
 
-  def test_search
-    stub_verb_request(:get, '/locations').
-      to_return(body: mock_search_body.to_json)
-    results = properties.search
-    assert_equal 1, results.first
-  end
-
-  private
-
-  def mock_search_body
-    {
-      pagination: {
-        limit: 3,
-        total: 6,
-        page: 1
-      }, 
-      content: [1, 2, 3]
-    }
+  def test_find
+    stub_verb_request(:get, '/locations', query: { query: 'test' }).
+      to_return(body: { name: 'test' }.to_json)
+    location = locations.find('test')
+    assert_equal 'test', location.name
   end
 end


### PR DESCRIPTION
Addresses issue #10.

EasyBroker's `/locations` endpoint returns unpaginated results, and the response should not be used by `EasyBroker::PaginatedResponse`. Using the `search` method name causes the misconception described in #10, since, `search` is the name we give to paginated/enumerable endpoints.

We'll now stop paginating the response and rename the method `search` to `find`, to make clear the response is not enumerable.